### PR TITLE
fix: Async bug in string interpolation

### DIFF
--- a/ExpressionEngine/ExpressionGrammar.cs
+++ b/ExpressionEngine/ExpressionGrammar.cs
@@ -111,15 +111,11 @@ namespace ExpressionEngine
                 from t in simpleString.Or(allowedCharacters).Many()
                 select string.Concat(t);
 
-            Parser<Task<ValueContainer>> joinedString =
-                from e in (
-                        from preFix in allowedString
-                        from exp in enclosedExpression.Optional()
-                        select exp.IsEmpty ? preFix : preFix + exp.Get().Result)
-                    // TODO - fix real async
-                    // @assignees: thygesteffensen
-                    .Many()
-                select Task.FromResult(new ValueContainer(string.Concat(e)));
+            Parser<Task<ValueContainer>> joinedString = allowedString
+                .SelectMany(preFix => enclosedExpression.Optional(),
+                    async (preFix, exp) => exp.IsEmpty ? preFix : preFix + await exp.Get())
+                .Many()
+                .Select(async e => await Task.FromResult(new ValueContainer(string.Concat(await Task.WhenAll(e)))));
 
             _input = expression.Or(joinedString);
         }

--- a/Test/ParserTest.cs
+++ b/Test/ParserTest.cs
@@ -126,10 +126,9 @@ namespace Test
         }
 
         private static TestInput[] _async =
-      {
-           
-            new TestInput("@{asynctest()} - @{asynctest()} - @{asynctest()}", new ValueContainer("Hello World - Hello World - Hello World")),
-
+        {
+            new TestInput("@{asynctest()} - @{asynctest()} - @{asynctest()}",
+                new ValueContainer("Hello World - Hello World - Hello World")),
         };
 
      


### PR DESCRIPTION
@pksorensen Giver dette mening?

Eller kan man lave `prefix` om til en Task, så man få en lang liste af tasks, der skal awaites, så man kan nøjes med at awaite i den sidste `Select()`?


---
When evaluating expression in a string, they must be awaited before joining the string.

Fixes #62, Fixes #60