### PR TITLE
Change double to decimal in internal ValueContainer float representation

### DIFF
--- a/ExpressionEngine/Functions/Implementations/ConversionFunctions/BoolFunction.cs
+++ b/ExpressionEngine/Functions/Implementations/ConversionFunctions/BoolFunction.cs
@@ -24,7 +24,7 @@ namespace ExpressionEngine.Functions.Implementations.ConversionFunctions
                     var intValue = parameters[0].GetValue<int>();
                     return new ValueTask<ValueContainer>(new ValueContainer(intValue > 0 || intValue < 0));
                 case ValueType.Float:
-                    var doubleValue = parameters[0].GetValue<double>();
+                    var doubleValue = parameters[0].GetValue<decimal>();
                     return new ValueTask<ValueContainer>(new ValueContainer(doubleValue > 0 || doubleValue < 0));
                 case ValueType.Boolean:
                     return new ValueTask<ValueContainer>(parameters[0]);

--- a/ExpressionEngine/Functions/Implementations/ConversionFunctions/FloatFunction.cs
+++ b/ExpressionEngine/Functions/Implementations/ConversionFunctions/FloatFunction.cs
@@ -17,16 +17,15 @@ namespace ExpressionEngine.Functions.Implementations.ConversionFunctions
             switch (parameters[0].Type())
             {
                 case ValueType.String:
-                    if (Double.TryParse(parameters[0].GetValue<string>(), out double doubleValue))
+                    if (decimal.TryParse(parameters[0].GetValue<string>(), out decimal doubleValue))
                     {
                         return new ValueTask<ValueContainer>(new ValueContainer(doubleValue));
                     }
-                    else if (Boolean.TryParse(parameters[0].GetValue<string>(), out bool boolVal))
+                    else if (bool.TryParse(parameters[0].GetValue<string>(), out bool boolVal))
                     {
-                        if (boolVal)
-                            return new ValueTask<ValueContainer>(new ValueContainer(1));
-                        else
-                            return new ValueTask<ValueContainer>(new ValueContainer(0));
+                        return boolVal
+                            ? new ValueTask<ValueContainer>(new ValueContainer(1))
+                            : new ValueTask<ValueContainer>(new ValueContainer(0));
                     }
                     else
                     {
@@ -35,13 +34,13 @@ namespace ExpressionEngine.Functions.Implementations.ConversionFunctions
                     }
 
                 case ValueType.Integer:
-                    return new ValueTask<ValueContainer>(new ValueContainer((float)parameters[0].GetValue<int>()));
+                    return new ValueTask<ValueContainer>(new ValueContainer((decimal)parameters[0].GetValue<int>()));
 
                 case ValueType.Float:
-                    return new ValueTask<ValueContainer>(new ValueContainer(parameters[0].GetValue<double>()));
+                    return new ValueTask<ValueContainer>(new ValueContainer(parameters[0].GetValue<decimal>()));
 
                 case ValueType.Boolean:
-                    return new ValueTask<ValueContainer>(new ValueContainer((double)(parameters[0].GetValue<bool>() ? 0 : 1)));
+                    return new ValueTask<ValueContainer>(new ValueContainer((decimal)(parameters[0].GetValue<bool>() ? 0 : 1)));
 
                 default:
                     throw new ExpressionEngineException(

--- a/ExpressionEngine/Functions/Implementations/ConversionFunctions/IntFunction.cs
+++ b/ExpressionEngine/Functions/Implementations/ConversionFunctions/IntFunction.cs
@@ -47,9 +47,9 @@ namespace ExpressionEngine.Functions.Implementations.ConversionFunctions
                     return new ValueTask<ValueContainer>(new ValueContainer(parameters[0].GetValue<int>()));
 
                 case ValueType.Float:
-                    var floatToIntVal = (int)System.Math.Round(parameters[0].GetValue<double>());
+                    var floatToIntVal = (int)System.Math.Round(parameters[0].GetValue<decimal>());
                     CheckIntMaxOrMin(floatToIntVal);
-                    return new ValueTask<ValueContainer>(new ValueContainer((int)System.Math.Round(parameters[0].GetValue<double>())));
+                    return new ValueTask<ValueContainer>(new ValueContainer((int)System.Math.Round(parameters[0].GetValue<decimal>())));
 
                 case ValueType.Boolean:
                     return new ValueTask<ValueContainer>(new ValueContainer(parameters[0].GetValue<bool>() ? 1 : 0));

--- a/ExpressionEngine/Functions/Implementations/Math/AddFunction.cs
+++ b/ExpressionEngine/Functions/Implementations/Math/AddFunction.cs
@@ -37,10 +37,22 @@ namespace ExpressionEngine.Functions.Math
                     "the first summand as the first parameter and the second summand as the second parameter.");
             }
 
-            var first = parameters[0].GetValue<double>();
-            var second = parameters[1].GetValue<double>();
+            var first = parameters[0];
+            var second = parameters[1];
 
-            return new ValueTask<ValueContainer>(new ValueContainer(first + second));
+            if (first.Type() == ValueType.Integer && second.Type() == ValueType.Integer)
+            {
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<int>() + second.GetValue<int>()));
+            }
+
+            if (first.IsNumber() && second.IsNumber())
+            {
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<decimal>() + second.GetValue<decimal>()));
+            }
+
+            throw new ExpressionEngineException($"Can only add numbers, not {first.Type()} and {second.Type()}");
         }
     }
 }

--- a/ExpressionEngine/Functions/Implementations/Math/DivFunction.cs
+++ b/ExpressionEngine/Functions/Implementations/Math/DivFunction.cs
@@ -42,17 +42,23 @@ namespace ExpressionEngine.Functions.Math
                     "The template language function 'div' expects two numeric parameters: " +
                     "the dividend as the first parameter and the divisor as the second parameter");
             }
+            
+            var first = parameters[0];
+            var second = parameters[1];
 
-            var first = parameters[0].GetValue<double>();
-            var second = parameters[1].GetValue<double>();
-
-            if (second == 0)
+            if (first.Type() == ValueType.Integer && second.Type() == ValueType.Integer)
             {
-                throw new ExpressionEngineException(
-                    "Attempt to divide an integral or decimal value by zero in function 'div'.");
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<int>() / second.GetValue<int>()));
             }
 
-            return new ValueTask<ValueContainer>(new ValueContainer(first / second));
+            if (first.IsNumber() && second.IsNumber())
+            {
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<decimal>() / second.GetValue<decimal>()));
+            }
+
+            throw new ExpressionEngineException($"Can only divide numbers, not {first.Type()} and {second.Type()}");
         }
     }
 }

--- a/ExpressionEngine/Functions/Implementations/Math/ModFunction.cs
+++ b/ExpressionEngine/Functions/Implementations/Math/ModFunction.cs
@@ -48,10 +48,22 @@ namespace ExpressionEngine.Functions.Math
                     "the dividend as the first parameter and the divisor as the second parameter");
             }
 
-            var first = parameters[0].GetValue<double>();
-            var second = parameters[1].GetValue<double>();
+            var first = parameters[0];
+            var second = parameters[1];
 
-            return new ValueTask<ValueContainer>(new ValueContainer(first % second));
+            if (first.Type() == ValueType.Integer && second.Type() == ValueType.Integer)
+            {
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<int>() % second.GetValue<int>()));
+            }
+
+            if (first.IsNumber() && second.IsNumber())
+            {
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<decimal>() % second.GetValue<decimal>()));
+            }
+
+            throw new ExpressionEngineException($"Can only mod numbers, not {first.Type()} and {second.Type()}");
         }
     }
 }

--- a/ExpressionEngine/Functions/Implementations/Math/MulFunction.cs
+++ b/ExpressionEngine/Functions/Implementations/Math/MulFunction.cs
@@ -42,10 +42,22 @@ namespace ExpressionEngine.Functions.Math
                     "the first multiplicand as the first parameter and the second multiplicand as the second parameter");
             }
 
-            var first = parameters[0].GetValue<double>();
-            var second = parameters[1].GetValue<double>();
+            var first = parameters[0];
+            var second = parameters[1];
 
-            return new ValueTask<ValueContainer>(new ValueContainer(first * second));
+            if (first.Type() == ValueType.Integer && second.Type() == ValueType.Integer)
+            {
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<int>() * second.GetValue<int>()));
+            }
+
+            if (first.IsNumber() && second.IsNumber())
+            {
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<decimal>() * second.GetValue<decimal>()));
+            }
+
+            throw new ExpressionEngineException($"Can only add numbers, not {first.Type()} and {second.Type()}");
         }
     }
 }

--- a/ExpressionEngine/Functions/Implementations/Math/SubFunction.cs
+++ b/ExpressionEngine/Functions/Implementations/Math/SubFunction.cs
@@ -38,10 +38,22 @@ namespace ExpressionEngine.Functions.Math
                     "the minuend as the first parameter and the subtrahend as the second parameter");
             }
 
-            var first = parameters[0].GetValue<double>();
-            var second = parameters[1].GetValue<double>();
+            var first = parameters[0];
+            var second = parameters[1];
 
-            return new ValueTask<ValueContainer>(new ValueContainer(first - second));
+            if (first.Type() == ValueType.Integer && second.Type() == ValueType.Integer)
+            {
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<int>() - second.GetValue<int>()));
+            }
+
+            if (first.IsNumber() && second.IsNumber())
+            {
+                return new ValueTask<ValueContainer>(
+                    new ValueContainer(first.GetValue<decimal>() - second.GetValue<decimal>()));
+            }
+
+            throw new ExpressionEngineException($"Can only add numbers, not {first.Type()} and {second.Type()}");
         }
     }
 }

--- a/ExpressionEngine/Functions/Implementations/StringFunctions/FormatNumberFunction.cs
+++ b/ExpressionEngine/Functions/Implementations/StringFunctions/FormatNumberFunction.cs
@@ -48,7 +48,7 @@ namespace ExpressionEngine.Functions.Implementations.StringFunctions
 
             if (value.Type() == ValueType.Float)
             {
-                var floatValue = value.GetValue<double>();
+                var floatValue = value.GetValue<decimal>();
 
                 return new ValueTask<ValueContainer>(new ValueContainer(floatValue.ToString(format, CultureInfo.CreateSpecificCulture(locale))));
             }

--- a/Test/Expression/ConversionFunctionTest.cs
+++ b/Test/Expression/ConversionFunctionTest.cs
@@ -181,21 +181,21 @@ namespace Test.Expression
                 new FloatFunction(),
                 "float",
                 new[] {new ValueContainer(0)},
-                new ValueContainer(0)
+                new ValueContainer(0m)
             },
             new object[]
             {
                 new FloatFunction(),
                 "float",
                 new[] {new ValueContainer(10005000)},
-                new ValueContainer(10005000)
+                new ValueContainer(10005000m)
             },
             new object[]
             {
                 new FloatFunction(),
                 "float",
                 new[] {new ValueContainer(-10000078)},
-                new ValueContainer(-10000078)
+                new ValueContainer(-10000078m)
             },
             new object[]
             {

--- a/Test/Expression/MathFunctionTests.cs
+++ b/Test/Expression/MathFunctionTests.cs
@@ -34,7 +34,7 @@ namespace Test.Expression
                 new DivFunction(),
                 "div",
                 new[] {new ValueContainer(5), new ValueContainer(0.5)},
-                new ValueContainer(10)
+                new ValueContainer(10m)
             },
             new object[]
             {

--- a/Test/ExpressionGrammarTest.cs
+++ b/Test/ExpressionGrammarTest.cs
@@ -103,7 +103,7 @@ namespace Test
         public async Task NegativeNumbers()
         {
             var expectedOutput1 = new ValueContainer(-1);
-            var expectedOutput2 = new ValueContainer(-3.14);
+            var expectedOutput2 = new ValueContainer(-3.14m);
             var expectedOutput3 = new ValueContainer(1);
             var expectedOutput4 = new ValueContainer(3.14);
             const string expressionString = "@dummyFunction(-1, -3.14, +1, +3.14)";


### PR DESCRIPTION
Why: FloatFunction.cs had a cast to C# float, which resulted in loss of information for a user. This resulted in the discussion of the VC Float type to be changed to `decimal` to ensure the most floating point number information is kept throughout the execution of an expression